### PR TITLE
Create dbo.usp_MakeFamilyPurchase.sql

### DIFF
--- a/dbo.usp_MakeFamilyPurchase.sql
+++ b/dbo.usp_MakeFamilyPurchase.sql
@@ -1,0 +1,20 @@
+USE SQLTest
+GO
+CREATE PROCEDURE dbo.usp_MakeFamilyPurchase
+	@FamilySurName VARCHAR(255)
+AS
+BEGIN
+	IF NOT EXISTS (SELECT 1 FROM dbo.Family WHERE SurName = @FamilySurName)
+	BEGIN
+		RAISERROR('Семьи с фамилией %s не существует.', 16, 1, @FamilySurName)
+		RETURN;
+	END;
+
+	UPDATE dbo.Family
+	SET BudgetValue = BudgetValue - (Select Sum(Value) 
+									From dbo.Basket 
+									JOIN dbo.Family ON dbo.Basket.ID_Family = dbo.Family.ID 
+									Where Family.SurName = @FamilySurName)
+	Where SurName = @FamilySurName;
+END;
+GO


### PR DESCRIPTION
Создать процедуру (на выходе: файл в репозитории dbo.usp_MakeFamilyPurchase в ветке Procedures
5.1 Входной параметр (@FamilySurName varchar(255)) одно из значений атрибута SurName таблицы dbo.Family
5.2 Процедура при вызове обновляет данные в таблицы dbo.Family в поле BudgetValue по логике
   5.2.1 dbo.Family.BudgetValue - sum(dbo.Basket.Value), где dbo.Basket.Value покупки для переданной в процедуру семьи
   5.2.2 При передаче несуществующего dbo.Family.SurName пользователю выдается ошибка, что такой семьи нет